### PR TITLE
SndMixer: Set default master volume to 95% to match the default config

### DIFF
--- a/src/libdev/sound/soundmix.cpp
+++ b/src/libdev/sound/soundmix.cpp
@@ -98,7 +98,7 @@ void SndMixerImpl::sort()
 
 Snd::Volume SndMixerImpl::hardwareMasterSampleVolume() const
 {
-	Snd::Volume theVol = 1;
+	Snd::Volume theVol = 95;
 	return theVol;
 }
 


### PR DESCRIPTION
The volume value is specified in percents (`alSourcef` accepts the volume in range 0..1) and we normalize this value from `volume_` and `masterSampleVolume()` (both in range 0..100).
https://github.com/markol/machines/blob/8dcbafc8e20024298df0faf9d1487859e0d6e54c/src/libdev/sound/alsample.cpp#L383-L384

1% perceived as a bug ("no sound at all")