### PR TITLE
Fix two different crashes on game save/load

### DIFF
--- a/include/libdev/machlog/oreholo.hpp
+++ b/include/libdev/machlog/oreholo.hpp
@@ -57,6 +57,8 @@ public:
 	
 	friend class MachLogMineralSite;
 
+	void assignToDifferentRace( MachLogRace& newRace );
+
 protected:
 	virtual void doStartExplodingAnimation();
 	virtual void doEndExplodingAnimation();

--- a/src/libdev/machlog/oreholo.cpp
+++ b/src/libdev/machlog/oreholo.cpp
@@ -136,6 +136,16 @@ const MachLogMineralSite& MachLogOreHolograph::mineralSite() const
 	return *pRetVal;
 }
 
+void MachLogOreHolograph::assignToDifferentRace(MachLogRace &newRace)
+{
+	// OreHolograph race change does not work:
+	// Save files do not have Holographes but only MineralSites
+	// During the load MineralSites create Holographes for the 'Race discoveredBy_'
+
+	// See void perRead( PerIstream& istr, MachLogMineralSiteImpl& siteImpl ) in minesiti.cpp:64 for details
+	return;
+}
+
 void MachLogOreHolograph::removeMe()
 {
 	isDead( true );

--- a/src/libdev/machlog/persist.cpp
+++ b/src/libdev/machlog/persist.cpp
@@ -126,7 +126,11 @@ void MachLogPersistence::setDataForWrite() const
 	{
 		if( MachLogRaces::instance().raceObjects( i ).size() > 0 )
 		{
-			nonConstPer.controllers_.push_back( &MachLogRaces::instance().controller( i ) );
+			MachLogController *pController = &MachLogRaces::instance().controller( i );
+			if ( !pController )
+				continue;
+
+			nonConstPer.controllers_.push_back( pController );
 		}
 	}
 }

--- a/src/libdev/machlog/squadi.cpp
+++ b/src/libdev/machlog/squadi.cpp
@@ -70,6 +70,9 @@ void perRead( PerIstream& istr, MachLogSquadronImpl& actorImpl )
 	istr >> actorImpl.totalDesiredMachines_;
 	istr >> actorImpl.setDefCon_;
 	istr >> actorImpl.defCon_;
+
+	actorImpl.pStrongestMachine_ = nullptr;
+	actorImpl.squadronHasChanged_ = true;
 }
 
 MachLogSquadronImpl::MachLogSquadronImpl( PerConstructor )


### PR DESCRIPTION
- The game crashed because of uninitialized new variables in `MachLogSquadronImpl` (e.g. `pStrongestMachine_ = 1` and `squadronHasChanged_ = 0`)
- The game crashed on load of saved game in the first (not training) mission.

Steps to reproduce the second crash:
1. Get the base in the first mission (Holo assigned from GREEN to RED)
2. Save the game (GREEN controller is not saved because it has no objects)
3. Load that save file (Holo re-created for GREEN but there is no controller)
4. Save the game (the current code happily writes garbage from `pController=nullptr`)
5. Load that new save file (crash on trying to recreate the stuff according to the garbage)
